### PR TITLE
feat(gop): implements the graphics output protocol via axdisplay.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.2#84eb2
 dependencies = [
  "axdriver_base",
  "axdriver_block",
+ "axdriver_display",
  "virtio-drivers",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ axconfig = { git = "https://github.com/arceos-org/arceos.git" }
 axsync = { git = "https://github.com/arceos-org/arceos.git" }
 axalloc = { git = "https://github.com/arceos-org/arceos.git", optional = true }
 axmm = { git = "https://github.com/arceos-org/arceos.git", optional = true }
-axdriver = { git = "https://github.com/arceos-org/arceos.git", optional = true, features = ["virtio-blk"] }
+axdriver = { git = "https://github.com/arceos-org/arceos.git", optional = true, features = ["virtio-blk", "virtio-gpu"] }
 axfs = { git = "https://github.com/arceos-org/arceos.git", optional = true }
 axnet = { git = "https://github.com/arceos-org/arceos.git", optional = true }
 axdisplay = { git = "https://github.com/arceos-org/arceos.git", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,6 @@ build: clean defconfig all
 
 qemu-run:
 	qemu-system-riscv64 -m 128M -serial mon:stdio -bios $(SBI) -nographic -machine virt -nographic -machine virt -device virtio-blk-pci,drive=disk0 -drive id=disk0,if=none,format=raw,file=$(DISK)
+
+qemu-display:
+	qemu-system-riscv64 -m 128M -serial mon:stdio -bios $(SBI) -machine virt -device virtio-blk-pci,drive=disk0 -drive id=disk0,if=none,format=raw,file=$(DISK) -device virtio-gpu-pci,xres=1024,yres=768

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Reuse [ArceOS](https://github.com/arceos-org/arceos) components to build a cross
 ```bash
 # for serial output build:
 $ make
-$ make run-qemu
+$ make qemu-run
 
 # for qemu virtual monitor:
 # this may require a desktop system or graphical infrastructure 
 # such as x11 forwarding configured on your host machine.
 $ make EXACT_FEATURES="display"
-$ make run-display
+$ make qemu-display
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # ArceBoot
 Reuse [ArceOS](https://github.com/arceos-org/arceos) components to build a cross-platform operating system bootloader
+
+# Build
+
+```bash
+# for serial output build:
+$ make
+$ make run-qemu
+
+# for qemu virtual monitor:
+# this may require a desktop system or graphical infrastructure 
+# such as x11 forwarding configured on your host machine.
+$ make EXACT_FEATURES="display"
+$ make run-display
+```

--- a/scripts/make/build.mk
+++ b/scripts/make/build.mk
@@ -8,6 +8,16 @@ ELF := $(ROOT_DIR)/target/$(TARGET)/release/arceboot
 BIN := $(ROOT_DIR)/target/$(TARGET)/release/arceboot.bin
 RUSTSBI_DIR := $(ROOT_DIR)/rustsbi
 
+# 用逗号或者空格分隔 feature 名称
+EXACT_FEATURES ?=
+EXACT_FEATURES_CLEANED := $(subst $(space),$(comma),$(strip $(EXACT_FEATURES)))
+
+ifeq ($(strip $(EXACT_FEATURES)),)
+  FEATURE_ARGS :=
+else
+  FEATURE_ARGS := --features '$(EXACT_FEATURES_CLEANED)'
+endif
+
 # 彩色打印
 define print_info
 	@printf "\033[1;37m%s\033[0m" "[RustSBI-Arceboot Build] "
@@ -22,7 +32,7 @@ all: build-arceboot extract-bin clone-rustsbi build-rustsbi
 
 build-arceboot:
 	$(call print_info,开始编译 ArceBoot...)
-	cargo rustc --release --target $(TARGET) -- \
+	cargo rustc --release --target $(TARGET) $(FEATURE_ARGS) -- \
 		-C opt-level=z \
 		-C panic=abort \
 		-C relocation-model=static \

--- a/src/runtime/protocol/graphics_output.rs
+++ b/src/runtime/protocol/graphics_output.rs
@@ -100,7 +100,7 @@ impl Drop for GraphicsOutput {
 }
 
 #[inline]
-fn with_go<F, R>(this: *const GraphicsOutputProtocol, f: F) -> Option<R>
+fn with_go<F, R>(_this: *const GraphicsOutputProtocol, f: F) -> Option<R>
 where
     F: FnOnce(&GraphicsOutput) -> R,
 {
@@ -326,6 +326,6 @@ pub unsafe extern "efiapi" fn blt(
     _width: usize,
     _height: usize,
     _delta: usize,
-) {
+) -> Status {
     Status::UNSUPPORTED
 }

--- a/src/runtime/protocol/graphics_output.rs
+++ b/src/runtime/protocol/graphics_output.rs
@@ -6,7 +6,7 @@ use uefi_raw::{
     Status,
     protocol::console::{
         GraphicsOutputBltOperation, GraphicsOutputBltPixel, GraphicsOutputModeInformation,
-        GraphicsOutputProtocol, GraphicsOutputProtocolMode,
+        GraphicsOutputProtocol, GraphicsOutputProtocolMode, GraphicsPixelFormat, PixelBitmask,
     },
 };
 
@@ -16,21 +16,55 @@ static GRAPHICS_OUTPUT: LazyInit<Mutex<GraphicsOutput>> = LazyInit::new();
 pub struct GraphicsOutput {
     protocol: &'static mut GraphicsOutputProtocol,
     protocol_raw: *mut GraphicsOutputProtocol,
+
+    mode_box: *mut GraphicsOutputProtocolMode,
+    info_box: *mut GraphicsOutputModeInformation,
+
     width: u32,
     height: u32,
     fb_base_vaddr: usize,
     fb_size: usize,
+    stride_pixels: u32,
 }
 
 impl GraphicsOutput {
-    pub fn new(width: u32, height: u32, fb_base_vaddr: usize, fb_size: usize) -> Self {
-        let mode: *mut GraphicsOutputProtocolMode = core::ptr::null_mut();
+    pub fn new(
+        width: u32,
+        height: u32,
+        fb_base_vaddr: usize,
+        fb_size: usize,
+        stride_pixels: u32,
+    ) -> Self {
+        let info = GraphicsOutputModeInformation {
+            version: 0,
+            horizontal_resolution: width,
+            vertical_resolution: height,
+            pixel_format: GraphicsPixelFormat::PIXEL_BLUE_GREEN_RED_RESERVED_8_BIT_PER_COLOR,
+            pixel_information: PixelBitmask {
+                red: 0,
+                green: 0,
+                blue: 0,
+                reserved: 0,
+            },
+            pixels_per_scan_line: stride_pixels,
+        };
+        let info_box = Box::into_raw(Box::new(info));
+
+        let mode = GraphicsOutputProtocolMode {
+            max_mode: 1,
+            mode: 0,
+            info: info_box,
+            size_of_info: size_of::<GraphicsOutputModeInformation>(),
+            frame_buffer_base: fb_base_vaddr as u64,
+            frame_buffer_size: fb_size,
+        };
+        let mode_box = Box::into_raw(Box::new(mode));
 
         let protocol = GraphicsOutputProtocol {
             query_mode,
             set_mode,
             blt,
-            mode,
+            mode: mode_box,
         };
 
         let protocol_raw = Box::into_raw(Box::new(protocol));
@@ -39,10 +73,13 @@ impl GraphicsOutput {
         Self {
             protocol,
             protocol_raw,
+            mode_box,
+            info_box,
             width,
             height,
             fb_base_vaddr,
             fb_size,
+            stride_pixels,
         }
     }
 
@@ -60,6 +97,17 @@ impl Drop for GraphicsOutput {
             drop(Box::from_raw(self.protocol_raw));
         }
     }
+}
+
+#[inline]
+fn with_go<F, R>(this: *const GraphicsOutputProtocol, f: F) -> Option<R>
+where
+    F: FnOnce(&GraphicsOutput) -> R,
+{
+    GRAPHICS_OUTPUT.get().map(|m| {
+        let lock = m.lock();
+        f(&*lock)
+    })
 }
 
 pub fn init_graphics_output() {
@@ -82,37 +130,196 @@ pub fn init_graphics_output() {
             display_info.height,
             display_info.fb_base_vaddr,
             display_info.fb_size,
+            // FIXME: in most real device environments, pixels are not equal to width.
+            // refer: https://docs.rs/bootloader_api/latest/bootloader_api/info/struct.FrameBufferInfo.html#structfield.stride
+            display_info.width,
         )));
     }
 }
 
 pub unsafe extern "efiapi" fn query_mode(
-    _this: *const GraphicsOutputProtocol,
-    _mode_number: u32,
-    _size_of_info: *mut usize,
-    _info: *mut *const GraphicsOutputModeInformation,
+    this: *const GraphicsOutputProtocol,
+    mode_number: u32,
+    size_of_info: *mut usize,
+    info: *mut *const GraphicsOutputModeInformation,
 ) -> Status {
-    Status::UNSUPPORTED
+    if mode_number != 0 {
+        return Status::UNSUPPORTED;
+    }
+    if size_of_info.is_null() || info.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+
+    match with_go(this, |go| (go.mode_box, go.info_box)) {
+        Some((mode_box, info_box)) => unsafe {
+            let mode = &*mode_box;
+            *size_of_info = mode.size_of_info;
+            *info = info_box as *const GraphicsOutputModeInformation;
+            Status::SUCCESS
+        },
+        None => Status::DEVICE_ERROR,
+    }
 }
 
 pub unsafe extern "efiapi" fn set_mode(
-    _this: *mut GraphicsOutputProtocol,
-    _mode_number: u32,
+    this: *mut GraphicsOutputProtocol,
+    mode_number: u32,
 ) -> Status {
-    Status::UNSUPPORTED
+    if mode_number != 0 {
+        return Status::UNSUPPORTED;
+    }
+    match with_go(this, |go| go.mode_box) {
+        Some(mode_box) => {
+            let mode = unsafe { &mut *mode_box };
+            mode.mode = 0;
+            // TODO: if resolution switching is supported in the future,
+            // info / stride / fb will be updated here, etc.
+            Status::SUCCESS
+        }
+        None => Status::DEVICE_ERROR,
+    }
 }
 
 pub unsafe extern "efiapi" fn blt(
-    _this: *mut GraphicsOutputProtocol,
-    _blt_buffer: *mut GraphicsOutputBltPixel,
-    _blt_operation: GraphicsOutputBltOperation,
-    _source_x: usize,
-    _source_y: usize,
-    _destination_x: usize,
-    _destination_y: usize,
-    _width: usize,
-    _height: usize,
-    _delta: usize,
+    this: *mut GraphicsOutputProtocol,
+    blt_buffer: *mut GraphicsOutputBltPixel,
+    blt_operation: GraphicsOutputBltOperation,
+    source_x: usize,
+    source_y: usize,
+    destination_x: usize,
+    destination_y: usize,
+    width: usize,
+    height: usize,
+    delta: usize,
 ) -> Status {
-    Status::UNSUPPORTED
+    #[cfg(feature = "display")]
+    {
+        let Some((fb_base, fb_size, w, h, stride_px)) = with_go(this, |go| {
+            (
+                go.fb_base_vaddr,
+                go.fb_size,
+                go.width as usize,
+                go.height as usize,
+                go.stride_pixels as usize,
+            )
+        }) else {
+            return Status::DEVICE_ERROR;
+        };
+
+        if width == 0 || height == 0 {
+            return Status::SUCCESS;
+        }
+
+        if destination_x >= w
+            || destination_y >= h
+            || destination_x + width > w
+            || destination_y + height > h
+        {
+            return Status::INVALID_PARAMETER;
+        }
+
+        let bytes_per_pixel = 4usize;
+        let fb_pitch = stride_px * bytes_per_pixel;
+        let fb = fb_base as *mut u8;
+
+        unsafe {
+            match blt_operation {
+                GraphicsOutputBltOperation::BLT_VIDEO_FILL => {
+                    // fill (dest_x, dest_y, width, height) with the color of blt_buffer[0]
+                    if blt_buffer.is_null() {
+                        return Status::INVALID_PARAMETER;
+                    }
+                    let px = *blt_buffer;
+                    let color = [px.blue, px.green, px.red, 0]; // BGRA
+                    for row in 0..height {
+                        let row_ptr = fb.add(
+                            (destination_y + row) * fb_pitch + destination_x * bytes_per_pixel,
+                        );
+                        for col in 0..width {
+                            let p = row_ptr.add(col * bytes_per_pixel);
+                            // 写 B,G,R,A
+                            *p.add(0) = color[0];
+                            *p.add(1) = color[1];
+                            *p.add(2) = color[2];
+                            *p.add(3) = color[3];
+                        }
+                    }
+                    axdisplay::framebuffer_flush();
+                    Status::SUCCESS
+                }
+                GraphicsOutputBltOperation::BLT_VIDEO_TO_BLT_BUFFER => {
+                    if blt_buffer.is_null() {
+                        return Status::INVALID_PARAMETER;
+                    }
+
+                    // Each row in BLT buffer: if Delta == 0, tightly packed (Width * 4 bytes).
+                    let dst_pitch = if delta == 0 {
+                        width * bytes_per_pixel
+                    } else {
+                        delta
+                    };
+
+                    for row in 0..height {
+                        // Source: read pixels from framebuffer at (source_x, source_y + row).
+                        let src = fb.add((source_y + row) * fb_pitch + source_x * bytes_per_pixel);
+
+                        // Destination: write into BLT buffer at (destination_x, destination_y + row).
+                        let dst = (blt_buffer as *mut u8).add(
+                            (destination_y + row) * dst_pitch + destination_x * bytes_per_pixel,
+                        );
+
+                        // Copy one scan line (Width * 4 bytes).
+                        core::ptr::copy_nonoverlapping(src, dst, width * bytes_per_pixel);
+                    }
+
+                    Status::SUCCESS
+                }
+                GraphicsOutputBltOperation::BLT_BUFFER_TO_VIDEO => {
+                    if blt_buffer.is_null() {
+                        return Status::INVALID_PARAMETER;
+                    }
+                    // in UEFI GOP spec, Delta = bytes per scan line in the BLT buffer.
+                    // if Delta == 0, it means the buffer is tightly packed: Width * sizeof(BltPixel) = Width * 4.
+                    let src_pitch = if delta == 0 {
+                        width * bytes_per_pixel
+                    } else {
+                        delta
+                    };
+
+                    for row in 0..height {
+                        let dst = fb.add(
+                            (destination_y + row) * fb_pitch + destination_x * bytes_per_pixel,
+                        );
+                        let src = (blt_buffer as *const u8)
+                            .add((source_y + row) * src_pitch + source_x * bytes_per_pixel);
+                        core::ptr::copy_nonoverlapping(src, dst, width * bytes_per_pixel);
+                    }
+                    axdisplay::framebuffer_flush();
+                    Status::SUCCESS
+                }
+                GraphicsOutputBltOperation::BLT_VIDEO_TO_VIDEO => {
+                    // internal memory transfer, supporting overlap (memmove semantics)
+                    let src_x = source_x;
+                    let src_y = source_y;
+                    if src_x >= w || src_y >= h || src_x + width > w || src_y + height > h {
+                        return Status::INVALID_PARAMETER;
+                    }
+                    for row in 0..height {
+                        let dst = fb.add(
+                            (destination_y + row) * fb_pitch + destination_x * bytes_per_pixel,
+                        );
+                        let src = fb.add((src_y + row) * fb_pitch + src_x * bytes_per_pixel);
+                        core::ptr::copy(src, dst, width * bytes_per_pixel);
+                    }
+                    axdisplay::framebuffer_flush();
+                    Status::SUCCESS
+                }
+                _ => Status::UNSUPPORTED,
+            }
+        }
+    }
+    #[cfg(not(feature = "display"))]
+    {
+        Status::UNSUPPORTED
+    }
 }

--- a/src/runtime/system_table.rs
+++ b/src/runtime/system_table.rs
@@ -47,10 +47,12 @@ pub fn init_system_table() {
     // Initialize the protocols
     init_block_io();
     init_device_path();
+
     #[cfg(feature = "display")]
     crate::runtime::protocol::graphics_output::init_graphics_output();
     #[cfg(feature = "fs")]
     crate::runtime::protocol::fs::simple_file_system::init_simple_file_system();
+
     let simple_text_output = {
         init_simple_text_output();
         get_simple_text_output().lock().get_protocol()


### PR DESCRIPTION
Changes in this PR:

1. Import [arceos/axdisplay](https://github.com/arceos-org/arceos/tree/main/modules/axdisplay) dependency and build script.
2. Implement `query_mode()`, `set_mode()` and `blt()` in the graphics output protocol through axdisplay.
3. A short build description is created in README.md.