### PR TITLE
test(allocate): added test program for allocate_page().

### DIFF
--- a/scripts/test/build_edk2.sh
+++ b/scripts/test/build_edk2.sh
@@ -7,7 +7,7 @@ EDK_DIR="$WORKSPACE_DIR/edk2"
 
 mkdir -p "$WORKSPACE_DIR"
 
-echo "[1/3] 准备 EDK2 构建环境..."
+echo "[1/4] 准备 EDK2 构建环境..."
 cd "$WORKSPACE_DIR"
 
 if [ ! -d "ToolChain/RISCV" ]; then
@@ -19,7 +19,7 @@ else
     echo "RISCV 工具链已存在，跳过下载。"
 fi
 
-echo "[2/3] 克隆 EDK2 仓库..."
+echo "[2/4] 克隆 EDK2 仓库..."
 if [ ! -d "$EDK_DIR" ]; then
     git clone --recurse-submodule https://github.com/tianocore/edk2.git "$EDK_DIR"
 else
@@ -28,7 +28,7 @@ fi
 
 export PATH="$WORKSPACE_DIR/ToolChain/RISCV/riscv/bin:$PATH"
 
-echo "[3/3] 构建 EDK2..."
+echo "[3/4] 构建 EDK2..."
 cd "$WORKSPACE_DIR"
 
 export WORKSPACE=`pwd`
@@ -40,6 +40,7 @@ export EDK_TOOLS_PATH=$WORKSPACE/edk2/BaseTools
 make -C edk2/BaseTools
 . "$EDK_DIR/edksetup.sh" BaseTools
 
+echo "[4/4] 准备 HelloRiscv 和 AllocatePage 示例..."
 # mkdir -p "$EDK_DIR/Hello"
 # cp -r "$PROJECT_ROOT/tests/edk2-Hello" "$EDK_DIR"
 # mv "$EDK_DIR/edk2-Hello"/* "$EDK_DIR/Hello/"
@@ -50,4 +51,8 @@ cp -r "$PROJECT_ROOT/tests/edk2-HelloRiscv" "$EDK_DIR"
 mv "$EDK_DIR/edk2-HelloRiscv" "$EDK_DIR/HelloRiscv/"
 build -a RISCV64 -t GCC5 -p "$EDK_DIR/HelloRiscv/HelloRiscv.dsc"
 
-echo "EDK2 构建完成。生成的镜像位于：$WORKSPACE_DIR/Build/DEBUG_GCC5/RISCV64/HelloRiscv.efi"
+cp -r "$PROJECT_ROOT/tests/edk2-AllocatePage" "$EDK_DIR"
+mv "$EDK_DIR/edk2-AllocatePage" "$EDK_DIR/AllocatePage/"
+build -a RISCV64 -t GCC5 -p "$EDK_DIR/AllocatePage/AllocatePage.dsc"
+
+echo "EDK2 与示例构建完成。生成的文件位于：$WORKSPACE_DIR/Build/DEBUG_GCC5/RISCV64"

--- a/scripts/test/check_allocate_test.sh
+++ b/scripts/test/check_allocate_test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+LOG_FILE="qemu.log"
+TARGET_STRING="EFI Output: 0xDEADBEEF12345678"
+
+if [ ! -f "$LOG_FILE" ]; then
+    echo "❌ $LOG_FILE 不存在"
+    exit 1
+fi
+
+if grep -qF "$TARGET_STRING" "$LOG_FILE"; then
+    echo "✅ 找到匹配日志行"
+    exit 0
+else
+    echo "❌ 未找到匹配日志行"
+    exit 2
+fi

--- a/tests/edk2-AllocatePage/AllocatePage.c
+++ b/tests/edk2-AllocatePage/AllocatePage.c
@@ -1,0 +1,128 @@
+#ifndef EFIAPI
+#define EFIAPI
+#endif
+
+/* basic integer aliases */
+typedef unsigned long long  u64;
+typedef unsigned int        u32;
+typedef unsigned short      u16;
+typedef unsigned char       u8;
+
+/* ---- Offsets (match the layout that produced SystemTable) ---- */
+enum { OFF_ST_CONOUT        = 64 };  /* EfiSystemTable->conOut */
+enum { OFF_ST_BOOTSERVICES  = 96 };  /* EfiSystemTable->bootServices */
+enum { OFF_CONOUT_OUTPUTSTRING = 8 };/* EfiSimpleTextOutputProtocol->output_string */
+enum { OFF_BS_ALLOCATEPAGES = 40 };  /* BootServices->AllocatePages */
+
+/* AllocatePages() parameters */
+enum {
+  kAllocateAnyPages    = 0,
+  kEfiBootServicesCode = 3
+};
+
+
+#define MAX_OUTPUT_CHARS 260
+
+typedef u64 (*EfiTextString)(void* This, u16* String);
+typedef u64 (*EfiAllocatePages)(u32 Type, u32 MemoryType, u64 Pages, u64* Memory);
+
+/* 
+ * Ensure instruction cache is synchronized with recently written code.
+ * On RISC-V, `fence.i` flushes the instruction pipeline and makes sure
+ * subsequent instruction fetches observe the updated memory contents.
+ */
+static inline void fence_i(void) { __asm__ __volatile__("fence.i" ::: "memory"); }
+
+static void mem_copy(void* dst, const void* src, u64 n) {
+  u8* d = (u8*)dst;
+  const u8* s = (const u8*)src;
+  while (n--) *d++ = *s++;
+}
+
+/* ASCII -> UTF-16 (Char16) and print via ConOut->OutputString */
+static void put_ascii(void* SystemTable, const char* s) {
+  if (!SystemTable || !s) return;
+
+  void* con_out = *(void**)((u8*)SystemTable + OFF_ST_CONOUT);
+  if (!con_out) return;
+
+  EfiTextString OutputString = *(EfiTextString*)((u8*)con_out + OFF_CONOUT_OUTPUTSTRING);
+  if (!OutputString) return;
+
+  u16 buf[MAX_OUTPUT_CHARS];
+  u32 i = 0;
+  for (; s[i] && i < (MAX_OUTPUT_CHARS - 1); ++i) buf[i] = (u16)(u8)s[i];
+  buf[i] = 0;
+
+  OutputString(con_out, buf);
+}
+
+/* print hex64 with optional label, ends with CRLF */
+static void put_hex64(void* SystemTable, const char* label, u64 v) {
+  static const char hex[] = "0123456789ABCDEF";
+  char tmp[2 + 16 + 2 + 1]; /* "0x" + 16 nybbles + "\r\n" + NUL */
+  int p = 0;
+
+  if (label) put_ascii(SystemTable, label);
+
+  tmp[p++] = '0';
+  tmp[p++] = 'x';
+  for (int i = 15; i >= 0; --i)
+    tmp[p++] = hex[(unsigned)((v >> (i * 4)) & 0xF)];
+  tmp[p++] = '\r';
+  tmp[p++] = '\n';
+  tmp[p] = 0;
+
+  put_ascii(SystemTable, tmp);
+}
+
+/* tiny payload: "ret" for RISC-V (jalr x0, x1, 0 -> 0x00008067) */
+static const u8 payload_ret_only[4] __attribute__((section(".payload"))) = { 0x67, 0x80, 0x00, 0x00 };
+
+typedef u64 (*payload_entry_t)(u64, u64, u64, u64, u64);
+
+/* Entry: alloc exec pages, copy payload, fence.i, call, log, return */
+u64 EFIAPI _ModuleEntryPoint(void* ImageHandle, void* SystemTable) {
+  (void)ImageHandle;
+
+  void* BootServices = *(void**)((u8*)SystemTable + OFF_ST_BOOTSERVICES);
+  if (!BootServices) return 1;
+
+  EfiAllocatePages AllocatePages = *(EfiAllocatePages*)((u8*)BootServices + OFF_BS_ALLOCATEPAGES);
+  if (!AllocatePages) return 2;
+
+  put_ascii(SystemTable, "[OK] C AllocatePages started\r\n");
+
+  u64 payload_size = (u64)sizeof(payload_ret_only);
+  if (payload_size == 0) {
+    put_ascii(SystemTable, "[ERR] payload_size=0\r\n");
+    return 5;
+  }
+
+  u64 pages = (payload_size + 0xFFFu) >> 12;
+  if (pages == 0) pages = 1;
+
+  u64 exec = 0;
+  u64 st = AllocatePages(kAllocateAnyPages, kEfiBootServicesCode, pages, &exec);
+  if (st != 0 || exec == 0) {
+    put_hex64(SystemTable, "[ERR] AllocatePages st=", st);
+    return st ? st : 6;
+  }
+
+  put_hex64(SystemTable, "[OK] exec_addr=", exec);
+  put_hex64(SystemTable, "[OK] pages    =", pages);
+
+  mem_copy((void*)(u64)exec, payload_ret_only, payload_size);
+  fence_i();
+
+  put_ascii(SystemTable, "[OK] calling payload...\r\n");
+
+  payload_entry_t entry = (payload_entry_t)(void*)(u64)exec;
+  u64 expected = 0xDEADBEEF12345678ull;
+  u64 ret = entry(expected, 0, 0, 0, 0);
+
+  put_hex64(SystemTable, "[OK] payload_ret=", ret);
+  put_ascii(SystemTable, "[OK] done\r\n");
+
+  return 0;
+}

--- a/tests/edk2-AllocatePage/AllocatePage.dsc
+++ b/tests/edk2-AllocatePage/AllocatePage.dsc
@@ -1,0 +1,14 @@
+[Defines]
+  PLATFORM_NAME           = AllocatePage
+  PLATFORM_GUID           = 01234567-89ab-cdef-0123-456789abcdef
+  PLATFORM_VERSION        = 1.0
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build
+  SUPPORTED_ARCHITECTURES = RISCV64
+  BUILD_TARGETS           = DEBUG
+
+[Components]
+  AllocatePage/AllocatePage.inf
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/tests/edk2-AllocatePage/AllocatePage.inf
+++ b/tests/edk2-AllocatePage/AllocatePage.inf
@@ -1,0 +1,16 @@
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                     = AllocatePage
+  FILE_GUID                     = 01234567-89ab-cdef-0123-456789abcdef
+  MODULE_TYPE                   = UEFI_APPLICATION
+  VERSION_STRING                = 1.0
+  ENTRY_POINT                   = efi_main
+
+[Sources]
+  AllocatePage.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  

--- a/tests/edk2-AllocatePage/payload.S
+++ b/tests/edk2-AllocatePage/payload.S
@@ -1,0 +1,22 @@
+    .text
+    .p2align 2
+    .global _start        # entry symbol name for payload (not used by EFI; we will call by address)
+_start:
+    # Convention:
+    # a0 = framebuffer base (u64)
+    # a1 = framebuffer size (u64)
+    # a2 = stride_pixels (u32)  (optional)
+    # a3 = width (u32)         (optional)
+    # a4 = height (u32)        (optional)
+
+    # Simple, position-independent loop: write 0xFF408DEB (32-bit) across framebuffer.
+    li      t0, 0xff408deb    # color constant (fits 32-bit)
+    mv      t1, a0            # ptr = fb_base
+    add     t2, a0, a1        # end = fb_base + fb_size
+
+1:  sw      t0, 0(t1)
+    addi    t1, t1, 4
+    bltu    t1, t2, 1b
+
+    # never return: infinite loop
+2:  j       2b

--- a/tests/edk2-AllocatePage/payload_embed.S
+++ b/tests/edk2-AllocatePage/payload_embed.S
@@ -1,0 +1,22 @@
+// payload_embed.S — return-only payload; safe without framebuffer
+// 返回：a0 = a0+a1+a2+a3+a4 + 0x123456789ABCDEF0
+
+    .section .payload, "ax", @progbits
+    .p2align 2
+    .globl _payload_start
+    .globl _payload_end
+_payload_start:
+
+    .globl entry
+    .type  entry, @function
+entry:
+    add     t0, a0, a1
+    add     t0, t0, a2
+    add     t0, t0, a3
+    add     t0, t0, a4
+    li      t1, 0x123456789ABCDEF0
+    add     a0, t0, t1
+    ret
+
+    .size entry, .-entry
+_payload_end:


### PR DESCRIPTION
Changes in this PR:

1. Introduces an EDK2-compatible EFI program that uses the allocate_page() function in BootService to allocate readable, writable, and executable memory, load RISCV machine code, and execute it.
2. Minor modifications to the current test script.