### PR TITLE
feat(device): impl utilities to assist in managing device path.

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -11,6 +11,13 @@ mod system_table;
 mod utils;
 
 pub fn efi_runtime_init() {
+    // Prepare the UEFI System Table
+    let system_table = {
+        system_table::init_system_table();
+        system_table::get_system_table_raw()
+    };
+
+    // Load the bootloader EFI file
     let load_bootloader = loader::load_efi_file("/EFI/BOOT/BOOTRISCV64.EFI");
     let image_base =
         loader::detect_and_get_image_base(&load_bootloader).expect("Failed to get PE image base");
@@ -39,12 +46,6 @@ pub fn efi_runtime_init() {
     );
 
     let func = entry::resolve_entry_func(mapping, file.entry(), base_va);
-
-    let system_table = {
-        system_table::init_system_table();
-        system_table::get_system_table_raw()
-    };
-
     let result = func(core::ptr::null_mut(), system_table);
     info!("efi_main return: {}", result);
 }

--- a/src/runtime/protocol/block_io.rs
+++ b/src/runtime/protocol/block_io.rs
@@ -17,9 +17,10 @@ pub struct BlockIo {
     protocol_raw: *mut BlockIoProtocol,
 }
 
+// https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#block-i-o-protocol
 impl BlockIo {
     pub fn new() -> Self {
-        let media: *const BlockIoMedia = core::ptr::null(); // stub; replace with actual media if needed
+        let media: *const BlockIoMedia = core::ptr::null();
 
         let protocol = BlockIoProtocol {
             revision: 0x00010000,

--- a/src/runtime/protocol/device/device_path_from_text.rs
+++ b/src/runtime/protocol/device/device_path_from_text.rs
@@ -1,0 +1,54 @@
+use axsync::Mutex;
+use lazyinit::LazyInit;
+use uefi_raw::{
+    Char16,
+    protocol::device_path::{DevicePathFromTextProtocol, DevicePathProtocol},
+};
+
+use alloc::boxed::Box;
+
+static DEVICE_PATH_FROM_TEXT: LazyInit<Mutex<DevicePathFromText>> = LazyInit::new();
+
+#[derive(Debug)]
+pub struct DevicePathFromText {
+    protocol: &'static mut DevicePathFromTextProtocol,
+    protocol_raw: *mut DevicePathFromTextProtocol,
+}
+
+impl DevicePathFromText {
+    pub fn new() -> Self {
+        let protocol = DevicePathFromTextProtocol {
+            convert_text_to_device_node,
+            convert_text_to_device_path,
+        };
+        let protocol_raw = Box::into_raw(Box::new(protocol));
+        let protocol = unsafe { &mut *protocol_raw };
+        Self {
+            protocol,
+            protocol_raw,
+        }
+    }
+
+    pub fn get_protocol(&self) -> *mut DevicePathFromTextProtocol {
+        self.protocol_raw
+    }
+}
+
+unsafe impl Send for DevicePathFromText {}
+unsafe impl Sync for DevicePathFromText {}
+
+pub fn init_device_path_from_text() {
+    DEVICE_PATH_FROM_TEXT.init_once(Mutex::new(DevicePathFromText::new()));
+}
+
+pub extern "efiapi" fn convert_text_to_device_node(
+    _text_device_node: *const Char16,
+) -> *const DevicePathProtocol {
+    core::ptr::null()
+}
+
+pub extern "efiapi" fn convert_text_to_device_path(
+    _text_device_path: *const Char16,
+) -> *const DevicePathProtocol {
+    core::ptr::null()
+}

--- a/src/runtime/protocol/device/device_path_to_text.rs
+++ b/src/runtime/protocol/device/device_path_to_text.rs
@@ -1,0 +1,58 @@
+use axsync::Mutex;
+use lazyinit::LazyInit;
+use uefi_raw::{
+    Boolean, Char16,
+    protocol::device_path::{DevicePathProtocol, DevicePathToTextProtocol},
+};
+
+use alloc::boxed::Box;
+
+static DEVICE_PATH_TO_TEXT: LazyInit<Mutex<DevicePathToText>> = LazyInit::new();
+
+#[derive(Debug)]
+pub struct DevicePathToText {
+    protocol: &'static mut DevicePathToTextProtocol,
+    protocol_raw: *mut DevicePathToTextProtocol,
+}
+
+impl DevicePathToText {
+    pub fn new() -> Self {
+        let protocol = DevicePathToTextProtocol {
+            convert_device_node_to_text,
+            convert_device_path_to_text,
+        };
+        let protocol_raw = Box::into_raw(Box::new(protocol));
+        let protocol = unsafe { &mut *protocol_raw };
+        Self {
+            protocol,
+            protocol_raw,
+        }
+    }
+
+    pub fn get_protocol(&self) -> *mut DevicePathToTextProtocol {
+        self.protocol_raw
+    }
+}
+
+unsafe impl Send for DevicePathToText {}
+unsafe impl Sync for DevicePathToText {}
+
+pub fn init_device_path_to_text() {
+    DEVICE_PATH_TO_TEXT.init_once(Mutex::new(DevicePathToText::new()));
+}
+
+pub extern "efiapi" fn convert_device_node_to_text(
+    _device_node: *const DevicePathProtocol,
+    _display_only: Boolean,
+    _allow_shortcuts: Boolean,
+) -> *const Char16 {
+    core::ptr::null()
+}
+
+pub extern "efiapi" fn convert_device_path_to_text(
+    _device_path: *const DevicePathProtocol,
+    _display_only: Boolean,
+    _allow_shortcuts: Boolean,
+) -> *const Char16 {
+    core::ptr::null()
+}

--- a/src/runtime/protocol/device/mod.rs
+++ b/src/runtime/protocol/device/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod device_path_from_text;
+pub(crate) mod device_path_to_text;
+pub(crate) mod device_path_utilities;

--- a/src/runtime/protocol/device_path.rs
+++ b/src/runtime/protocol/device_path.rs
@@ -1,4 +1,8 @@
-use core::ptr::null_mut;
+use core::{
+    mem,
+    ptr::{self},
+    slice,
+};
 
 use axsync::Mutex;
 use lazyinit::LazyInit;
@@ -11,10 +15,99 @@ use uefi_raw::{
 };
 
 use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+// Device Path node type: 0x7F = End of Hardware Device Path
+const END_DEVICE_PATH_TYPE: u8 = 0x7F;
+// End node subtype: 0x01 = End Instance (marks end of one instance, more may follow)
+const END_INSTANCE_DEVICE_PATH_SUBTYPE: u8 = 0x01;
+// End node subtype: 0xFF = End Entire (marks end of the whole device path)
+const END_ENTIRE_DEVICE_PATH_SUBTYPE: u8 = 0xFF;
+// Common header size for every Device Path node (Type + SubType + Length[2])
+const DEV_PATH_HEADER_LEN: usize = 4;
 
 static DEVICE_PATH_TO_TEXT: LazyInit<Mutex<DevicePathToText>> = LazyInit::new();
 static DEVICE_PATH_FROM_TEXT: LazyInit<Mutex<DevicePathFromText>> = LazyInit::new();
 static DEVICE_PATH_UTILITIES: LazyInit<Mutex<DevicePathUtilities>> = LazyInit::new();
+
+pub fn init_device_path() {
+    DEVICE_PATH_TO_TEXT.init_once(Mutex::new(DevicePathToText::new()));
+    DEVICE_PATH_FROM_TEXT.init_once(Mutex::new(DevicePathFromText::new()));
+    DEVICE_PATH_UTILITIES.init_once(Mutex::new(DevicePathUtilities::new()));
+}
+
+#[inline]
+unsafe fn node_type(p: *const DevicePathProtocol) -> u8 {
+    unsafe { *(p as *const u8) }
+}
+#[inline]
+unsafe fn node_subtype(p: *const DevicePathProtocol) -> u8 {
+    unsafe { *((p as *const u8).add(1)) }
+}
+#[inline]
+unsafe fn node_len_u16(p: *const DevicePathProtocol) -> u16 {
+    // Little-endian 2 bytes at offset 2
+    // equivalent to read_unaligned((b+2) as *const u16)
+    unsafe { *(p as *const u16).add(1) }
+}
+#[inline]
+unsafe fn node_len(p: *const DevicePathProtocol) -> usize {
+    unsafe { node_len_u16(p) as usize }
+}
+#[inline]
+unsafe fn is_end(p: *const DevicePathProtocol) -> bool {
+    unsafe { node_type(p) == END_DEVICE_PATH_TYPE && node_len(p) >= DEV_PATH_HEADER_LEN }
+}
+#[inline]
+unsafe fn is_end_entire(p: *const DevicePathProtocol) -> bool {
+    unsafe { is_end(p) && node_subtype(p) == END_ENTIRE_DEVICE_PATH_SUBTYPE }
+}
+#[inline]
+unsafe fn is_end_instance(p: *const DevicePathProtocol) -> bool {
+    unsafe { is_end(p) && node_subtype(p) == END_INSTANCE_DEVICE_PATH_SUBTYPE }
+}
+
+#[inline]
+unsafe fn total_path_size(dp: *const DevicePathProtocol) -> Option<usize> {
+    if dp.is_null() {
+        return Some(0);
+    }
+    let mut cur = dp;
+    let mut total: usize = 0;
+    let hard_cap: usize = 1 << 20;
+
+    loop {
+        let len = unsafe { node_len(cur) };
+        if len < DEV_PATH_HEADER_LEN {
+            return None;
+        }
+        total = total.checked_add(len)?;
+        if total > hard_cap {
+            return None;
+        }
+        if unsafe { is_end_entire(cur) } {
+            break;
+        }
+        cur = unsafe { (cur as *const u8).add(len) } as *const DevicePathProtocol;
+    }
+    Some(total)
+}
+
+#[inline]
+unsafe fn copy_bytes_to_box(
+    dp: *const DevicePathProtocol,
+    size: usize,
+) -> *const DevicePathProtocol {
+    if size == 0 {
+        return ptr::null();
+    }
+    let src = unsafe { slice::from_raw_parts(dp as *const u8, size) };
+    let mut buf = Vec::<u8>::with_capacity(size);
+    buf.extend_from_slice(src);
+    let boxed = buf.into_boxed_slice();
+    let ptr_u8 = Box::into_raw(boxed) as *mut u8;
+    ptr_u8 as *const DevicePathProtocol
+}
 
 #[derive(Debug)]
 pub struct DevicePathToText {
@@ -43,12 +136,6 @@ impl DevicePathToText {
 
 unsafe impl Send for DevicePathToText {}
 unsafe impl Sync for DevicePathToText {}
-
-pub fn init_device_path() {
-    DEVICE_PATH_TO_TEXT.init_once(Mutex::new(DevicePathToText::new()));
-    DEVICE_PATH_FROM_TEXT.init_once(Mutex::new(DevicePathFromText::new()));
-    DEVICE_PATH_UTILITIES.init_once(Mutex::new(DevicePathUtilities::new()));
-}
 
 pub extern "efiapi" fn convert_device_node_to_text(
     _device_node: *const DevicePathProtocol,
@@ -140,54 +227,284 @@ impl DevicePathUtilities {
 unsafe impl Send for DevicePathUtilities {}
 unsafe impl Sync for DevicePathUtilities {}
 
-pub extern "efiapi" fn get_device_path_size(_device_path: *const DevicePathProtocol) -> usize {
-    0
+pub extern "efiapi" fn get_device_path_size(device_path: *const DevicePathProtocol) -> usize {
+    unsafe {
+        match total_path_size(device_path) {
+            Some(sz) => sz,
+            None => 0,
+        }
+    }
 }
 
 pub extern "efiapi" fn duplicate_device_path(
-    _device_path: *const DevicePathProtocol,
+    device_path: *const DevicePathProtocol,
 ) -> *const DevicePathProtocol {
-    null_mut()
+    unsafe {
+        match total_path_size(device_path) {
+            Some(0) => ptr::null_mut(),
+            Some(sz) => copy_bytes_to_box(device_path, sz) as *const _,
+            None => ptr::null_mut(),
+        }
+    }
 }
 
 pub extern "efiapi" fn append_device_path(
-    _src1: *const DevicePathProtocol,
-    _src2: *const DevicePathProtocol,
+    src1: *const DevicePathProtocol,
+    src2: *const DevicePathProtocol,
 ) -> *const DevicePathProtocol {
-    null_mut()
+    unsafe {
+        let s1_size = match total_path_size(src1) {
+            Some(0) => DEV_PATH_HEADER_LEN,
+            Some(sz) => sz,
+            None => return ptr::null_mut(),
+        };
+        let s2_size = match total_path_size(src2) {
+            Some(0) => DEV_PATH_HEADER_LEN,
+            Some(sz) => sz,
+            None => return ptr::null_mut(),
+        };
+
+        let s1_head = if s1_size >= DEV_PATH_HEADER_LEN {
+            s1_size - DEV_PATH_HEADER_LEN
+        } else {
+            0
+        };
+        let out_size = s1_head.checked_add(s2_size).unwrap_or(0);
+        if out_size == 0 {
+            return ptr::null_mut();
+        }
+
+        let mut out = Vec::<u8>::with_capacity(out_size);
+        if s1_head > 0 && !src1.is_null() {
+            out.extend_from_slice(slice::from_raw_parts(src1 as *const u8, s1_head));
+        } else {
+        }
+        if s2_size > 0 && !src2.is_null() {
+            out.extend_from_slice(slice::from_raw_parts(src2 as *const u8, s2_size));
+        } else {
+            out.extend_from_slice(&[
+                END_DEVICE_PATH_TYPE,
+                END_ENTIRE_DEVICE_PATH_SUBTYPE,
+                0x04,
+                0x00,
+            ]);
+        }
+
+        let boxed = out.into_boxed_slice();
+        Box::into_raw(boxed) as *const DevicePathProtocol
+    }
 }
 
 pub extern "efiapi" fn append_device_node(
-    _device_path: *const DevicePathProtocol,
-    _device_node: *const DevicePathProtocol,
+    device_path: *const DevicePathProtocol,
+    device_node: *const DevicePathProtocol,
 ) -> *const DevicePathProtocol {
-    null_mut()
+    unsafe {
+        if device_node.is_null() {
+            return duplicate_device_path(device_path);
+        }
+        let node_len_b = node_len(device_node);
+        if node_len_b < DEV_PATH_HEADER_LEN || is_end(device_node) {
+            return duplicate_device_path(device_path);
+        }
+
+        let dp_size = match total_path_size(device_path) {
+            Some(0) => DEV_PATH_HEADER_LEN,
+            Some(sz) => sz,
+            None => return ptr::null_mut(),
+        };
+
+        let dp_head = dp_size - DEV_PATH_HEADER_LEN;
+        let out_size = dp_head
+            .checked_add(node_len_b)
+            .and_then(|v| v.checked_add(DEV_PATH_HEADER_LEN))
+            .unwrap_or(0);
+        if out_size == 0 {
+            return ptr::null_mut();
+        }
+
+        let mut out = Vec::<u8>::with_capacity(out_size);
+        if dp_head > 0 && !device_path.is_null() {
+            out.extend_from_slice(slice::from_raw_parts(device_path as *const u8, dp_head));
+        }
+        out.extend_from_slice(slice::from_raw_parts(device_node as *const u8, node_len_b));
+        // End Entire
+        out.extend_from_slice(&[
+            END_DEVICE_PATH_TYPE,
+            END_ENTIRE_DEVICE_PATH_SUBTYPE,
+            0x04,
+            0x00,
+        ]);
+
+        let boxed = out.into_boxed_slice();
+        Box::into_raw(boxed) as *const DevicePathProtocol
+    }
 }
 
 pub extern "efiapi" fn append_device_path_instance(
-    _device_path: *const DevicePathProtocol,
-    _device_path_instance: *const DevicePathProtocol,
+    device_path: *const DevicePathProtocol,
+    device_path_instance: *const DevicePathProtocol,
 ) -> *const DevicePathProtocol {
-    null_mut()
+    unsafe {
+        let dp_size = match total_path_size(device_path) {
+            Some(0) => DEV_PATH_HEADER_LEN,
+            Some(sz) => sz,
+            None => return ptr::null_mut(),
+        };
+        let dp_head = dp_size - DEV_PATH_HEADER_LEN;
+        if device_path_instance.is_null() {
+            return duplicate_device_path(device_path);
+        }
+
+        let mut cur = device_path_instance;
+        let mut inst_len: usize = 0;
+        loop {
+            let len = node_len(cur);
+            if len < DEV_PATH_HEADER_LEN {
+                return ptr::null_mut();
+            }
+            inst_len = inst_len.checked_add(len).unwrap_or(0);
+            if is_end_instance(cur) || is_end_entire(cur) {
+                break;
+            }
+            cur = (cur as *const u8).add(len) as *const DevicePathProtocol;
+        }
+
+        // out = dp_head + inst_len + (End Entire 4B)
+        let out_size = dp_head
+            .checked_add(inst_len)
+            .and_then(|v| v.checked_add(DEV_PATH_HEADER_LEN))
+            .unwrap_or(0);
+        if out_size == 0 {
+            return ptr::null_mut();
+        }
+
+        let mut out = Vec::<u8>::with_capacity(out_size);
+        if dp_head > 0 && !device_path.is_null() {
+            out.extend_from_slice(slice::from_raw_parts(device_path as *const u8, dp_head));
+            out.extend_from_slice(&[
+                END_DEVICE_PATH_TYPE,
+                END_INSTANCE_DEVICE_PATH_SUBTYPE,
+                0x04,
+                0x00,
+            ]);
+        }
+        out.extend_from_slice(slice::from_raw_parts(
+            device_path_instance as *const u8,
+            inst_len,
+        ));
+        if let Some(last4) = out.get(out.len().saturating_sub(DEV_PATH_HEADER_LEN)..) {
+            out.truncate(out.len().saturating_sub(DEV_PATH_HEADER_LEN));
+        }
+        out.extend_from_slice(&[
+            END_DEVICE_PATH_TYPE,
+            END_ENTIRE_DEVICE_PATH_SUBTYPE,
+            0x04,
+            0x00,
+        ]);
+
+        let boxed = out.into_boxed_slice();
+        Box::into_raw(boxed) as *const DevicePathProtocol
+    }
 }
 
 pub extern "efiapi" fn get_next_device_path_instance(
-    _device_path_instance: *mut *const DevicePathProtocol,
-    _device_path_instance_size: *mut usize,
+    device_path_instance: *mut *const DevicePathProtocol,
+    device_path_instance_size: *mut usize,
 ) -> *const DevicePathProtocol {
-    null_mut()
+    unsafe {
+        if device_path_instance.is_null() || device_path_instance_size.is_null() {
+            return ptr::null_mut();
+        }
+        let mut cur = *device_path_instance;
+        if cur.is_null() {
+            *device_path_instance_size = 0;
+            return ptr::null_mut();
+        }
+
+        let start = cur as *const u8;
+        let mut p = cur;
+        let mut inst_bytes: usize = 0;
+        loop {
+            let len = node_len(p);
+            if len < DEV_PATH_HEADER_LEN {
+                return ptr::null_mut();
+            }
+            inst_bytes = inst_bytes.checked_add(len).unwrap_or(0);
+            if is_end_instance(p) || is_end_entire(p) {
+                break;
+            }
+            p = (p as *const u8).add(len) as *const DevicePathProtocol;
+        }
+
+        let mut out = Vec::<u8>::with_capacity(inst_bytes);
+        out.extend_from_slice(slice::from_raw_parts(start, inst_bytes));
+        if out.len() >= DEV_PATH_HEADER_LEN {
+            out.truncate(out.len() - DEV_PATH_HEADER_LEN);
+        }
+        out.extend_from_slice(&[
+            END_DEVICE_PATH_TYPE,
+            END_ENTIRE_DEVICE_PATH_SUBTYPE,
+            0x04,
+            0x00,
+        ]);
+
+
+        let after = (p as *const u8).add(DEV_PATH_HEADER_LEN);
+        if is_end_instance(p) {
+            *device_path_instance = after as *const DevicePathProtocol;
+        } else {
+            *device_path_instance = ptr::null();
+        }
+
+        *device_path_instance_size = out.len();
+        let boxed = out.into_boxed_slice();
+        Box::into_raw(boxed) as *const DevicePathProtocol
+    }
 }
 
 pub extern "efiapi" fn is_device_path_multi_instance(
-    _device_path: *const DevicePathProtocol,
+    device_path: *const DevicePathProtocol,
 ) -> bool {
-    true
+    unsafe {
+        if device_path.is_null() {
+            return false;
+        }
+        let mut p = device_path;
+        loop {
+            if is_end_instance(p) {
+                return true;
+            }
+            if is_end_entire(p) {
+                return false;
+            }
+            let len = node_len(p);
+            if len < DEV_PATH_HEADER_LEN {
+                return false;
+            }
+            p = (p as *const u8).add(len) as *const DevicePathProtocol;
+        }
+    }
 }
 
 pub extern "efiapi" fn create_device_node(
-    _node_type: DeviceType,
-    _node_sub_type: DeviceSubType,
-    _node_length: u16,
+    node_type: DeviceType,
+    node_sub_type: DeviceSubType,
+    node_length: u16,
 ) -> *const DevicePathProtocol {
-    null_mut()
+    unsafe {
+        if usize::from(node_length) < DEV_PATH_HEADER_LEN {
+            return ptr::null_mut();
+        }
+        let mut buf = Vec::<u8>::with_capacity(node_length as usize);
+        buf.resize(node_length as usize, 0u8);
+
+        buf[0] = mem::transmute::<DeviceType, u8>(node_type);
+        buf[1] = mem::transmute::<DeviceSubType, u8>(node_sub_type);
+        buf[2] = (node_length & 0x00FF) as u8;
+        buf[3] = (node_length >> 8) as u8;
+
+        let boxed = buf.into_boxed_slice();
+        Box::into_raw(boxed) as *const DevicePathProtocol
+    }
 }

--- a/src/runtime/protocol/mod.rs
+++ b/src/runtime/protocol/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod block_io;
-pub(crate) mod device_path;
+pub(crate) mod device;
 pub(crate) mod fs;
 pub(crate) mod graphics_output;
 pub(crate) mod handle;

--- a/src/runtime/system_table.rs
+++ b/src/runtime/system_table.rs
@@ -50,6 +50,8 @@ pub fn init_system_table() {
 
     #[cfg(feature = "display")]
     crate::runtime::protocol::graphics_output::init_graphics_output();
+    #[cfg(feature = "virtiodisk")]
+    crate::runtime::protocol::block_io::init_block_io();
     #[cfg(feature = "fs")]
     crate::runtime::protocol::fs::simple_file_system::init_simple_file_system();
 

--- a/src/runtime/system_table.rs
+++ b/src/runtime/system_table.rs
@@ -7,7 +7,11 @@ use uefi_raw::table::{Header, configuration::ConfigurationTable, system::SystemT
 use crate::runtime::{
     protocol::{
         block_io::init_block_io,
-        device_path::init_device_path,
+        device::{
+            device_path_from_text::init_device_path_from_text,
+            device_path_to_text::init_device_path_to_text,
+            device_path_utilities::init_device_path_uttilities,
+        },
         simple_text_output::{get_simple_text_output, init_simple_text_output},
     },
     service::{get_boot_service, get_runtime_service},
@@ -44,14 +48,15 @@ static VENDOR: &[u16] = &[
 static REVERSION: u32 = 0x0001_0000;
 
 pub fn init_system_table() {
-    // Initialize the protocols
+    // Initialize the tools.
+    init_device_path_from_text();
+    init_device_path_to_text();
+    init_device_path_uttilities();
+
     init_block_io();
-    init_device_path();
 
     #[cfg(feature = "display")]
     crate::runtime::protocol::graphics_output::init_graphics_output();
-    #[cfg(feature = "virtiodisk")]
-    crate::runtime::protocol::block_io::init_block_io();
     #[cfg(feature = "fs")]
     crate::runtime::protocol::fs::simple_file_system::init_simple_file_system();
 


### PR DESCRIPTION
Changes in this PR:

1. Implement the `get_device_path_size()`, `duplicate_device_path()`, `append_device_path()`, `append_device_node()`, `append_device_path_instance()`, `get_next_device_path_instance()`, `is_device_path_multi_instance()` and `create_device_node()` functions of DevicePathUtilities.


Note:

The UEFI Device Path is essentially a sequence of “nodes” (Device Path Nodes) arranged one after another. Each node starts with a fixed 4-byte header: `Type (1B) | SubType (1B) | Length (2B, little-endian)`. The Length field specifies the total size of the node, including the header and its payload, which varies depending on the node type. The entire path always ends with a terminator node: `Type=0x7F (End), SubType=0xFF (End Entire), Length=4`.

For multi-instance paths, different instances are separated by an End Instance node `(Type=0x7F, SubType=0x01, Length=4)`, and the whole path is still terminated by a final End Entire. Conceptually, the structure looks like: `[Node1][Node2]...[End Instance?]...[End Entire]` 

Together, the ordered nodes describe the exact location and access method for a device within the system.